### PR TITLE
Fix Sinatra gem dependancy at version 2.0.1

### DIFF
--- a/rubyhome.gemspec
+++ b/rubyhome.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rbnacl', '~> 5.0'
   spec.add_dependency 'rbnacl-libsodium', '~> 1.0', '>= 1.0.16'
   spec.add_dependency 'ruby_home-srp', '~> 1.1.1'
-  spec.add_dependency 'sinatra', '~> 2.0'
+  spec.add_dependency 'sinatra', '~> 2.0.1'
   spec.add_dependency 'wisper', '~> 1.6', '>= 1.6.1'
   spec.add_dependency 'x25519', '~> 1.0', '>= 1.0.5'
   spec.add_development_dependency 'bundler', '~> 1.16'


### PR DESCRIPTION
I guess the internals of Sinatra have changed in some breaking way that requires further investigation (at a later date) so we can use 2.0.3.

Closes #16