### PR TITLE
Remove e25519 gem dependancy

### DIFF
--- a/lib/ruby_home/accessory_info.rb
+++ b/lib/ruby_home/accessory_info.rb
@@ -1,4 +1,4 @@
-require 'ed25519'
+require 'rbnacl/libsodium'
 require 'yaml/store'
 require_relative 'device_id'
 
@@ -13,7 +13,7 @@ module RubyHome
 
       @device_id ||= DeviceID.generate
       @paired_clients ||= []
-      @signature_key ||= Ed25519::SigningKey.generate.to_bytes.unpack1('H*')
+      @signature_key ||= RbNaCl::Signatures::Ed25519::SigningKey.generate.to_bytes.unpack1('H*')
     end
 
     attr_reader :store
@@ -26,7 +26,7 @@ module RubyHome
     end
 
     def signing_key
-      @signing_key ||= Ed25519::SigningKey.new([signature_key].pack('H*'))
+      @signing_key ||= RbNaCl::Signatures::Ed25519::SigningKey.new([signature_key].pack('H*'))
     end
 
     def username

--- a/rubyhome.gemspec
+++ b/rubyhome.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'bindata', '~> 2.4', '>= 2.4.3'
   spec.add_dependency 'dnssd', '~> 3.0'
-  spec.add_dependency 'ed25519', '~> 1.2', '>= 1.2.3'
   spec.add_dependency 'hkdf', '~> 0.3.0'
   spec.add_dependency 'oj', '~> 3.4'
   spec.add_dependency 'rbnacl', '~> 5.0'

--- a/spec/lib/accessory_info_spec.rb
+++ b/spec/lib/accessory_info_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe RubyHome::AccessoryInfo do
 
   describe '.signing_key' do
     it 'returns a Ed25519::SigningKey' do
-      expect(RubyHome::AccessoryInfo.signing_key).to be_a(Ed25519::SigningKey)
+      expect(RubyHome::AccessoryInfo.signing_key).to be_a(RbNaCl::Signatures::Ed25519::SigningKey)
     end
   end
 


### PR DESCRIPTION
https://github.com/crypto-rb/rbnacl already provides this functionality so we can safely remove e25519 gem from the project