### PR TITLE
Added pairing error responses

### DIFF
--- a/lib/ruby_home/hap/tlv.rb
+++ b/lib/ruby_home/hap/tlv.rb
@@ -3,6 +3,16 @@ module RubyHome
     module TLV
       extend self
 
+      ERROR_CODES = {
+        1 => 'kTLVError_Unknown',
+        2 => 'kTLVError_Authentication',
+        3 => 'kTLVError_Backoff',
+        4 => 'kTLVError_MaxPeers',
+        5 => 'kTLVError_MaxTries',
+        6 => 'kTLVError_Unavailable',
+        7 => 'kTLVError_Busy',
+      }.freeze
+
       TYPE_NAMES = {
         0 => 'kTLVType_Method',
         1 => 'kTLVType_Identifier',
@@ -19,7 +29,6 @@ module RubyHome
        12 => 'kTLVType_FragmentData',
        13 => 'kTLVType_FragmentLast',
       }.freeze
-      NAME_TYPES = TYPE_NAMES.invert.freeze
 
       class Bytes < BinData::String; end
 
@@ -73,7 +82,7 @@ module RubyHome
 
       def encode(hash)
         hash.to_hash.each_with_object(String.new) do |(key, value), memo|
-          type_id = NAME_TYPES[key]
+          type_id = TYPE_NAMES.invert[key]
           next unless type_id
 
           if value.is_a?(String)

--- a/lib/ruby_home/http/controllers/pair_setups_controller.rb
+++ b/lib/ruby_home/http/controllers/pair_setups_controller.rb
@@ -18,6 +18,13 @@ module RubyHome
 
       private
 
+      def pairing_failed_response
+        HAP::TLV.encode({
+          'kTLVType_State' => 4,
+          'kTLVType_Error' => 2
+        })
+      end
+
       def srp_start_response
         username = AccessoryInfo.username
         password = AccessoryInfo.password
@@ -39,7 +46,10 @@ module RubyHome
 
       def srp_verify_response
         proof = retrieve_proof.dup
-        proof[:A] = unpack_request['kTLVType_PublicKey'].unpack1('H*')
+        public_key = unpack_request['kTLVType_PublicKey']
+        return pairing_failed_response unless public_key
+
+        proof[:A] = public_key.unpack1('H*')
 
         server_m2_proof = srp_verifier.verify_session(proof, unpack_request['kTLVType_Proof'].unpack1('H*'))
 

--- a/spec/http/requests/pair_setup_spec.rb
+++ b/spec/http/requests/pair_setup_spec.rb
@@ -80,6 +80,9 @@ RSpec.describe 'POST /pair-setup' do
         D15793F8 02099A46 C8D8FC4F 4D0B1E59 97311C8F DE59CC2E 22A5BF34 8A47D636
       }.join.downcase
     end
+    let(:data) do
+      File.read(File.expand_path('../../../fixtures/srp_verify_request', __FILE__))
+    end
 
     before do
       set_cache(:proof, {
@@ -89,38 +92,48 @@ RSpec.describe 'POST /pair-setup' do
         s: salt,
         v: verifier
       })
-      path = File.expand_path('../../../fixtures/srp_verify_request', __FILE__)
-      data = File.read(path)
       post '/pair-setup', data, { 'CONTENT_TYPE' => 'application/pairing+tlv8' }
     end
 
-    it 'headers contains application/pairing+tlv8 header' do
-      expect(last_response.headers).to include('Content-Type' => 'application/pairing+tlv8')
+    context 'valid verify response request' do
+      it 'headers contains application/pairing+tlv8 header' do
+        expect(last_response.headers).to include('Content-Type' => 'application/pairing+tlv8')
+      end
+
+      it 'body contains kTLVType_State' do
+        expect(unpacked_body).to include('kTLVType_State' => 4)
+      end
+
+      it 'body contains kTLVType_Proof' do
+        public_key = unpacked_body['kTLVType_Proof'].unpack1('H*')
+        expected_proof = %w{
+          986161DE 6D267DFE D08402CE 7A9EA5A0 27C09F04 2D70AD65 F374ADC7 D0F0F152
+          033B4B94 0583C317 0CD4C326 4BB093C0 B518F8C9 710B6F68 A56E5B03 D0686EDA
+        }.join.downcase
+        expect(public_key).to eql(expected_proof)
+      end
+
+      it 'stores session_key' do
+        expected_session_key = %w{
+          2B5F1FA4 046B2E63 2A06F1D9 612B031F 6D0B9676 B602DD36 BFCFEA0F 85D8567E
+          DDEBF2EF B5C24227 DF05D9F8 BECC3F32 518CEAAD BA5F689F 50252F6B E5D77EA6
+        }.join.downcase
+        expect(read_cache(:session_key)).to eql(expected_session_key)
+      end
+
+      it 'destroy proof' do
+        expect(read_cache(:proof)).to be_nil
+      end
     end
 
-    it 'body contains kTLVType_State' do
-      expect(unpacked_body).to include('kTLVType_State' => 4)
-    end
+    context 'invalid verify response request' do
+      context 'no kTLVType_PublicKey supplied' do
+        let(:data) { RubyHome::HAP::TLV.encode('kTLVType_State' => 3) }
 
-    it 'body contains kTLVType_Proof' do
-      public_key = unpacked_body['kTLVType_Proof'].unpack1('H*')
-      expected_proof = %w{
-        986161DE 6D267DFE D08402CE 7A9EA5A0 27C09F04 2D70AD65 F374ADC7 D0F0F152
-        033B4B94 0583C317 0CD4C326 4BB093C0 B518F8C9 710B6F68 A56E5B03 D0686EDA
-      }.join.downcase
-      expect(public_key).to eql(expected_proof)
-    end
-
-    it 'stores session_key' do
-      expected_session_key = %w{
-        2B5F1FA4 046B2E63 2A06F1D9 612B031F 6D0B9676 B602DD36 BFCFEA0F 85D8567E
-        DDEBF2EF B5C24227 DF05D9F8 BECC3F32 518CEAAD BA5F689F 50252F6B E5D77EA6
-      }.join.downcase
-      expect(read_cache(:session_key)).to eql(expected_session_key)
-    end
-
-    it 'destroy proof' do
-      expect(read_cache(:proof)).to be_nil
+        it 'responds with error' do
+          expect(unpacked_body).to include('kTLVType_State' => 4, 'kTLVType_Error' => 2)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Accessory -> iOS Device -- `SRP Verify Response'
- If verification fails, the accessory must respond with error