### PR TITLE
Add default values for commonly used characteristics

### DIFF
--- a/lib/ruby_home/factories/characteristic_factory.rb
+++ b/lib/ruby_home/factories/characteristic_factory.rb
@@ -1,12 +1,7 @@
 module RubyHome
   class CharacteristicFactory
     DEFAULT_VALUES = {
-      firmware_revision: '1.0',
       identify: nil,
-      manufacturer: 'Default-Manufacturer',
-      model: 'Default-Model',
-      name: 'RubyHome',
-      serial_number: 'Default-SerialNumber',
     }.freeze
 
     def self.create(characteristic_name, options={}, &block)
@@ -44,9 +39,13 @@ module RubyHome
 
       def default_value
         DEFAULT_VALUES.fetch(characteristic_name.to_sym) do
-          case template.format
-          when 'bool'
-            false
+          klass = "RubyHome::#{template.format.classify}DefaultValue".safe_constantize || NullDefaultValue
+          default_value = klass.new(template).default
+
+          if default_value.nil?
+            raise "No default value available for characteristic: #{characteristic_name} of type: #{template.format}"
+          else
+            default_value
           end
         end
       end

--- a/lib/ruby_home/factories/default_values/base_value.rb
+++ b/lib/ruby_home/factories/default_values/base_value.rb
@@ -1,0 +1,15 @@
+module RubyHome
+  class BaseValue
+    def initialize(template)
+      @template = template
+    end
+
+    def default
+      raise NotImplementedError
+    end
+
+    private
+
+      attr_reader :template
+  end
+end

--- a/lib/ruby_home/factories/default_values/bool_value.rb
+++ b/lib/ruby_home/factories/default_values/bool_value.rb
@@ -1,0 +1,9 @@
+require_relative 'base_value'
+
+module RubyHome
+  class BoolDefaultValue < BaseValue
+    def default
+      false
+    end
+  end
+end

--- a/lib/ruby_home/factories/default_values/float_value.rb
+++ b/lib/ruby_home/factories/default_values/float_value.rb
@@ -1,0 +1,15 @@
+require_relative 'base_value'
+
+module RubyHome
+  class FloatDefaultValue < BaseValue
+    def default
+      minimum_value.to_f
+    end
+
+    private
+
+      def minimum_value
+        template.constraints.fetch('MinimumValue')
+      end
+  end
+end

--- a/lib/ruby_home/factories/default_values/int32_value.rb
+++ b/lib/ruby_home/factories/default_values/int32_value.rb
@@ -1,0 +1,15 @@
+require_relative 'base_value'
+
+module RubyHome
+  class Int32DefaultValue < BaseValue
+    def default
+      minimum_value.to_i
+    end
+
+    private
+
+      def minimum_value
+        template.constraints.fetch('MinimumValue')
+      end
+  end
+end

--- a/lib/ruby_home/factories/default_values/null_value.rb
+++ b/lib/ruby_home/factories/default_values/null_value.rb
@@ -1,0 +1,9 @@
+require_relative 'base_value'
+
+module RubyHome
+  class NullDefaultValue < BaseValue
+    def default
+      nil
+    end
+  end
+end

--- a/lib/ruby_home/factories/default_values/string_value.rb
+++ b/lib/ruby_home/factories/default_values/string_value.rb
@@ -1,0 +1,24 @@
+require_relative 'base_value'
+
+module RubyHome
+  class StringDefaultValue < BaseValue
+    DEFAULT_VALUES = {
+      firmware_revision: '1.0',
+      hardware_revision: '1.0',
+      manufacturer: 'Default-Manufacturer',
+      model: 'Default-Model',
+      name: 'RubyHome',
+      serial_number: 'Default-SerialNumber',
+      version: '1.0',
+    }.freeze
+
+    def default
+      DEFAULT_VALUES[name]
+    end
+
+    private
+      def name
+        template.name
+      end
+  end
+end

--- a/lib/ruby_home/factories/default_values/uint32_value.rb
+++ b/lib/ruby_home/factories/default_values/uint32_value.rb
@@ -1,0 +1,20 @@
+require_relative 'base_value'
+
+module RubyHome
+  class Uint32DefaultValue < BaseValue
+    DEFAULT_VALUES = {
+      color_temperature: 50,
+      lock_management_auto_security_timeout: 0,
+    }.freeze
+
+    def default
+      DEFAULT_VALUES[name]
+    end
+
+    private
+
+      def name
+        template.name
+      end
+  end
+end

--- a/lib/ruby_home/factories/default_values/uint8_value.rb
+++ b/lib/ruby_home/factories/default_values/uint8_value.rb
@@ -1,0 +1,19 @@
+require_relative 'base_value'
+
+module RubyHome
+  class Uint8DefaultValue < BaseValue
+    def default
+      first_default_value.to_i
+    end
+
+    private
+
+      def first_default_value
+        valid_values.keys.first
+      end
+
+      def valid_values
+        template.constraints.fetch('ValidValues')
+      end
+  end
+end

--- a/spec/lib/factories/default_values/bool_value_spec.rb
+++ b/spec/lib/factories/default_values/bool_value_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe RubyHome::BoolDefaultValue do
+  describe '#default' do
+    it 'returns false' do
+      template = double
+      handler = RubyHome::BoolDefaultValue.new(template)
+      expect(handler.default).to eql(false)
+    end
+  end
+end

--- a/spec/lib/factories/default_values/float_value_spec.rb
+++ b/spec/lib/factories/default_values/float_value_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe RubyHome::FloatDefaultValue do
+  describe '#default' do
+    it 'returns minimum value from template constraints' do
+      template = double(constraints: { 'MinimumValue' => 10 } )
+      handler = RubyHome::FloatDefaultValue.new(template)
+      expect(handler.default).to eql(10.0)
+    end
+  end
+end

--- a/spec/lib/factories/default_values/int32_value_spec.rb
+++ b/spec/lib/factories/default_values/int32_value_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe RubyHome::Int32DefaultValue do
+  describe '#default' do
+    it 'returns minimum value from template constraints' do
+      template = double(constraints: { 'MinimumValue' => 10 } )
+      handler = RubyHome::Int32DefaultValue.new(template)
+      expect(handler.default).to eql(10)
+    end
+  end
+end

--- a/spec/lib/factories/default_values/string_value_spec.rb
+++ b/spec/lib/factories/default_values/string_value_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+RSpec.describe RubyHome::StringDefaultValue do
+  describe '#default' do
+    it 'returns 1.0 for Firmware Revision template' do
+      template = double(name: :firmware_revision)
+      handler = RubyHome::StringDefaultValue.new(template)
+      expect(handler.default).to eql('1.0')
+    end
+
+    it 'returns 1.0 for Hardware Revision' do
+      template = double(name: :hardware_revision)
+      handler = RubyHome::StringDefaultValue.new(template)
+      expect(handler.default).to eql('1.0')
+    end
+
+    it 'returns 1.0 for Hardware Revision' do
+      template = double(name: :version)
+      handler = RubyHome::StringDefaultValue.new(template)
+      expect(handler.default).to eql('1.0')
+    end
+
+    it 'returns Default-Manufacturer for Manufacturer' do
+      template = double(name: :manufacturer)
+      handler = RubyHome::StringDefaultValue.new(template)
+      expect(handler.default).to eql('Default-Manufacturer')
+    end
+
+    it 'returns Default-Model for Model' do
+      template = double(name: :model)
+      handler = RubyHome::StringDefaultValue.new(template)
+      expect(handler.default).to eql('Default-Model')
+    end
+
+    it 'returns RubyHome for Name' do
+      template = double(name: :name)
+      handler = RubyHome::StringDefaultValue.new(template)
+      expect(handler.default).to eql('RubyHome')
+    end
+
+    it 'returns Default-SerialNumber for Serial Number' do
+      template = double(name: :serial_number)
+      handler = RubyHome::StringDefaultValue.new(template)
+      expect(handler.default).to eql('Default-SerialNumber')
+    end
+
+    it 'returns nil for unknown template' do
+      template = double(name: :foo)
+      handler = RubyHome::StringDefaultValue.new(template)
+      expect(handler.default).to be_nil
+    end
+  end
+end

--- a/spec/lib/factories/default_values/uint32_value_spec.rb
+++ b/spec/lib/factories/default_values/uint32_value_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe RubyHome::Uint32DefaultValue do
+  describe '#default' do
+    it 'returns 0 for Lock Management Auto Security Timeout template' do
+      template = double(name: :lock_management_auto_security_timeout)
+      handler = RubyHome::Uint32DefaultValue.new(template)
+      expect(handler.default).to eql(0)
+    end
+
+    it 'returns 50 for Color Temperature template' do
+      template = double(name: :color_temperature)
+      handler = RubyHome::Uint32DefaultValue.new(template)
+      expect(handler.default).to eql(50)
+    end
+
+    it 'returns nil for any other template' do
+      template = double(name: :foo)
+      handler = RubyHome::Uint32DefaultValue.new(template)
+      expect(handler.default).to be_nil
+    end
+  end
+end

--- a/spec/lib/factories/default_values/uint8_value_spec.rb
+++ b/spec/lib/factories/default_values/uint8_value_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe RubyHome::Uint8DefaultValue do
+  describe '#default' do
+    it 'returns first default value from valid values' do
+      template = double(constraints: { 'ValidValues' => { '0' => 'Inactive' } } )
+      handler = RubyHome::Uint8DefaultValue.new(template)
+      expect(handler.default).to eql(0)
+    end
+  end
+end


### PR DESCRIPTION
Adding default values for [characteristics](https://github.com/karlentwistle/ruby_home/blob/master/lib/ruby_home/config/characteristics.yml) of format

- uint32
- uint8
- bool
- float
- int32
- string
- tlv8

Some of the default values might be a bit strange. This is just to get developers through the pairing stage so they can explore the project further. All default values can still be overwritten in the following manner.

```ruby
accessory_information = RubyHome::AccessoryFactory.create(:accessory_information)
door = RubyHome::AccessoryFactory.create(:garage_door_opener)
door.characteristic(:target_door_state).value = 1 # closed (default is open)
door.characteristic(:target_door_state).on(:updated) do |new_value|
  puts new_value.inspect
end

RubyHome.run
```

I've also tried to add a [slightly more helpful error message](https://github.com/karlentwistle/ruby_home/pull/33/files#diff-eb29bf564569976d0d5620aa5c6dbb8cR46) if the project still doesn't provide a characteristics default value. This could possibly be expanded on further but its a start 😅 

Known unsupported default value [characteristics](https://github.com/karlentwistle/ruby_home/blob/master/lib/ruby_home/config/characteristics.yml) of format

- tlv

Fixes #31