### PR TITLE
Fix uninitialized constant RubyHome::Accessory::AccessoryCollection

### DIFF
--- a/lib/ruby_home/hap/accessory.rb
+++ b/lib/ruby_home/hap/accessory.rb
@@ -1,3 +1,5 @@
+require_relative 'accessory_collection'
+
 module RubyHome
   class Accessory
     @@all = AccessoryCollection.new


### PR DESCRIPTION
Full stack trace

```
NameError: uninitialized constant RubyHome::Accessory::AccessoryCollection
Did you mean?  RubyHome::AccessoryInfo
/Users/travis/build/karlentwistle/ruby_home/lib/ruby_home/hap/accessory.rb:3:in `<class:Accessory>'
/Users/travis/build/karlentwistle/ruby_home/lib/ruby_home/hap/accessory.rb:2:in `<module:RubyHome>'
/Users/travis/build/karlentwistle/ruby_home/lib/ruby_home/hap/accessory.rb:1:in `<top (required)>'
/Users/travis/build/karlentwistle/ruby_home/lib/ruby_home.rb:19:in `require'
/Users/travis/build/karlentwistle/ruby_home/lib/ruby_home.rb:19:in `block in <module:RubyHome>'
/Users/travis/build/karlentwistle/ruby_home/lib/ruby_home.rb:19:in `each'
/Users/travis/build/karlentwistle/ruby_home/lib/ruby_home.rb:19:in `<module:RubyHome>'
/Users/travis/build/karlentwistle/ruby_home/lib/ruby_home.rb:18:in `<top (required)>'
/Users/travis/build/karlentwistle/ruby_home/Rakefile:3:in `require_relative'
/Users/travis/build/karlentwistle/ruby_home/Rakefile:3:in `<top (required)>'
/Users/travis/.rvm/gems/ruby-2.5.1/gems/rake-12.3.1/exe/rake:27:in `<top (required)>'
/Users/travis/.rvm/gems/ruby-2.5.1/bin/ruby_executable_hooks:15:in `eval'
/Users/travis/.rvm/gems/ruby-2.5.1/bin/ruby_executable_hooks:15:in `<main>'
(See full trace by running task with --trace)
```