### PR TITLE
Fix building against ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 install:
   - 'gem update --system'
   - 'gem --version'
-  - 'gem install bundler'
+  - 'gem install bundler -v 2.0.1'
   - 'bundle --version'
   - bundle
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 install:
   - 'gem update --system'
   - 'gem --version'
-  - 'gem install bundler -v 1.17.1'
+  - 'gem install bundler'
   - 'bundle --version'
   - bundle
 rvm:

--- a/rubyhome.gemspec
+++ b/rubyhome.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sinatra', '2.0.5'
   spec.add_dependency 'wisper', '~> 2.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'byebug', '~> 10.0'
   spec.add_development_dependency 'plist', '~> 3.4'
   spec.add_development_dependency 'rack-test', '~> 1.1.0'


### PR DESCRIPTION
Fix building `ruby-head`. 

Error from Travis:

```raw
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.16)

  Current Bundler version:
    bundler (2.0.1)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (~> 1.16)' in any of the relevant sources:
  the local ruby installation

Your build has been stopped.
```