### PR TITLE
Configuring Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The following is the full list of available configuration options:
 ```ruby
 model_name # The user-visible name of the accessory, e.g. "LED Bulb M123"
 password # Used for pairing must conform to the format XXX-XX-XXX where each X is a 0-9 digit and dashes are required, e.g. "101-48-005"
+port # The port that should be used when starting the built-in web server, e.g. 8080
 ```
 
 ## Customization

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ end
 The following is the full list of available configuration options:
 
 ```ruby
-model_name # The user-visible name of the accessory, e.g. "LED Bulb M123" (String)
+discovery_name # The user-visible name of the accessory, e.g. "LED Bulb M123" (String)
+model_name # The model name of the accessory, e.g. "Device1,1" (String)
 password # Used for pairing must conform to the format XXX-XX-XXX where each X is a 0-9 digit and dashes are required, e.g. "101-48-005" (String)
 bind # The hostname or IP address of the interface to listen on, e.g. "192.168.0.2" (String)
 port # The port that should be used when starting the built-in web server, e.g. 8080 (Integer)

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ end
 The following is the full list of available configuration options:
 
 ```ruby
-model_name # The user-visible name of the accessory, e.g. "LED Bulb M123"
-password # Used for pairing must conform to the format XXX-XX-XXX where each X is a 0-9 digit and dashes are required, e.g. "101-48-005"
-bind # The hostname or IP address of the interface to listen on, e.g. "192.168.0.2"
-port # The port that should be used when starting the built-in web server, e.g. 8080
+model_name # The user-visible name of the accessory, e.g. "LED Bulb M123" (String)
+password # Used for pairing must conform to the format XXX-XX-XXX where each X is a 0-9 digit and dashes are required, e.g. "101-48-005" (String)
+bind # The hostname or IP address of the interface to listen on, e.g. "192.168.0.2" (String)
+port # The port that should be used when starting the built-in web server, e.g. 8080 (Integer)
 ```
 
 ## Customization

--- a/README.md
+++ b/README.md
@@ -64,19 +64,19 @@ The configuration options can be set by using the `configure` helper
 
 ```ruby
 RubyHome.configure do |c|
-  c.model_name = 'My House'
+  c.discovery_name = 'My Home'
 end
 ```
 
 The following is the full list of available configuration options:
 
-```ruby
-discovery_name # The user-visible name of the accessory, e.g. "LED Bulb M123" (String)
-model_name # The model name of the accessory, e.g. "Device1,1" (String)
-password # Used for pairing must conform to the format XXX-XX-XXX where each X is a 0-9 digit and dashes are required, e.g. "101-48-005" (String)
-bind # The hostname or IP address of the interface to listen on, e.g. "192.168.0.2" (String)
-port # The port that should be used when starting the built-in web server, e.g. 8080 (Integer)
-```
+| Method | Description | Default | Example | Type |
+|---|---|---|---|---|
+| `discovery_name` |  The user-visible name of the accessory | `"RubyHome"` | `"My Home"` | String |
+| `model_name` |  The model name of the accessory | `"RubyHome"` | `"Device1,1"` | String |
+| `password` | Used for pairing must conform to the format XXX-XX-XXX where each X is a 0-9 digit and dashes are required | Randomly generated | `"101-48-005"` | String |
+| `bind` | The hostname or IP address of the interface to listen on | `"0.0.0.0"` | `"192.168.0.2"` | String  |
+| `port` | The port that should be used when starting the built-in web server | `4567` | `8080` | Integer |
 
 ## Customization
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The following is the full list of available configuration options:
 | `discovery_name` |  The user-visible name of the accessory | `"RubyHome"` | `"My Home"` | String |
 | `model_name` |  The model name of the accessory | `"RubyHome"` | `"Device1,1"` | String |
 | `password` | Used for pairing must conform to the format XXX-XX-XXX where each X is a 0-9 digit and dashes are required | Randomly generated | `"101-48-005"` | String |
-| `bind` | The hostname or IP address of the interface to listen on | `"0.0.0.0"` | `"192.168.0.2"` | String  |
+| `host` | The hostname or IP address of the interface to listen on | `"0.0.0.0"` | `"192.168.0.2"` | String  |
 | `port` | The port that should be used when starting the built-in web server | `4567` | `8080` | Integer |
 
 ## Customization

--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ end
 RubyHome.run
 ```
 
+## Configuration
+
+The configuration options can be set by using the `configure` helper
+
+```ruby
+RubyHome.configure do |c|
+  c.model_name = 'My House'
+end
+```
+
+The following is the full list of available configuration options:
+
+```ruby
+model_name # The user-visible name of the accessory, e.g. "LED Bulb M123"
+```
+
 ## Customization
 
 RubyHome tries to provide sane defaults for all services. Customization of any of the options is possible.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The following is the full list of available configuration options:
 ```ruby
 model_name # The user-visible name of the accessory, e.g. "LED Bulb M123"
 password # Used for pairing must conform to the format XXX-XX-XXX where each X is a 0-9 digit and dashes are required, e.g. "101-48-005"
+bind # The hostname or IP address of the interface to listen on, e.g. "192.168.0.2"
 port # The port that should be used when starting the built-in web server, e.g. 8080
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The following is the full list of available configuration options:
 
 ```ruby
 model_name # The user-visible name of the accessory, e.g. "LED Bulb M123"
+password # Used for pairing must conform to the format XXX-XX-XXX where each X is a 0-9 digit and dashes are required, e.g. "101-48-005"
 ```
 
 ## Customization

--- a/lib/ruby_home.rb
+++ b/lib/ruby_home.rb
@@ -57,7 +57,7 @@ module RubyHome
     end
 
     def hap_server
-      @_hap_server ||= HAP::Server.new('0.0.0.0', 4567)
+      @_hap_server ||= HAP::Server.new('0.0.0.0', configuration.port)
     end
 
     def greet

--- a/lib/ruby_home.rb
+++ b/lib/ruby_home.rb
@@ -57,7 +57,7 @@ module RubyHome
     end
 
     def hap_server
-      @_hap_server ||= HAP::Server.new('0.0.0.0', configuration.port)
+      @_hap_server ||= HAP::Server.new(configuration.bind, configuration.port)
     end
 
     def greet

--- a/lib/ruby_home.rb
+++ b/lib/ruby_home.rb
@@ -18,6 +18,16 @@ module RubyHome
   Dir[File.dirname(__FILE__) + '/ruby_home/**/*.rb'].each { |file| require file }
 
   class << self
+    def configuration
+      @_configuration ||= Configuration.new
+    end
+
+    alias_method :config, :configuration
+
+    def configure
+      yield configuration
+    end
+
     def run
       trap 'INT'  do shutdown end
       trap 'TERM' do shutdown end

--- a/lib/ruby_home.rb
+++ b/lib/ruby_home.rb
@@ -53,7 +53,7 @@ module RubyHome
     end
 
     def dns_service
-      @_dns_service ||= DNS::Service.new(hap_server.port)
+      @_dns_service ||= DNS::Service.new(configuration: configuration)
     end
 
     def hap_server

--- a/lib/ruby_home.rb
+++ b/lib/ruby_home.rb
@@ -57,7 +57,7 @@ module RubyHome
     end
 
     def hap_server
-      @_hap_server ||= HAP::Server.new(configuration.bind, configuration.port)
+      @_hap_server ||= HAP::Server.new(configuration.host, configuration.port)
     end
 
     def greet

--- a/lib/ruby_home/accessory_info.rb
+++ b/lib/ruby_home/accessory_info.rb
@@ -15,11 +15,9 @@ module RubyHome
     end
 
     USERNAME = -'Pair-Setup'
-    DEFAULT_MODEL_NAME = -'RubyHome'
 
-    def initialize(device_id: nil, model_name: nil, paired_clients: [], password: nil, signature_key: nil)
+    def initialize(device_id: nil, paired_clients: [], password: nil, signature_key: nil)
       @device_id = device_id
-      @model_name = model_name
       @paired_clients = paired_clients
       @password = password
       @signature_key = signature_key
@@ -41,12 +39,6 @@ module RubyHome
     def device_id
       @device_id ||= DeviceID.generate
     end
-
-    def model_name
-      @model_name ||= DEFAULT_MODEL_NAME
-    end
-
-    attr_writer :model_name
 
     def paired_clients
       @paired_clients ||= []

--- a/lib/ruby_home/accessory_info.rb
+++ b/lib/ruby_home/accessory_info.rb
@@ -15,9 +15,11 @@ module RubyHome
     end
 
     USERNAME = -'Pair-Setup'
+    DEFAULT_MODEL_NAME = -'RubyHome'
 
-    def initialize(device_id: nil, paired_clients: [], password: nil, signature_key: nil)
+    def initialize(device_id: nil, model_name: nil, paired_clients: [], password: nil, signature_key: nil)
       @device_id = device_id
+      @model_name = model_name
       @paired_clients = paired_clients
       @password = password
       @signature_key = signature_key
@@ -34,6 +36,12 @@ module RubyHome
     def device_id
       @device_id ||= DeviceID.generate
     end
+
+    def model_name
+      @model_name ||= DEFAULT_MODEL_NAME
+    end
+
+    attr_writer :model_name
 
     def paired_clients
       @paired_clients ||= []

--- a/lib/ruby_home/accessory_info.rb
+++ b/lib/ruby_home/accessory_info.rb
@@ -33,6 +33,11 @@ module RubyHome
       @password ||= Password.generate
     end
 
+    def password=(new_password)
+      @password = new_password
+      save
+    end
+
     def device_id
       @device_id ||= DeviceID.generate
     end

--- a/lib/ruby_home/configuration.rb
+++ b/lib/ruby_home/configuration.rb
@@ -6,9 +6,15 @@ module RubyHome
       @accessory_info = accessory_info
     end
 
+    DEFAULT_NAME = -'RubyHome'
     DEFAULT_BIND = -'0.0.0.0'
     DEFAULT_PORT = 4567
-    DEFAULT_MODEL_NAME = -'RubyHome'
+    DEFAULT_MODEL_NAME = DEFAULT_NAME
+    DEFAULT_DISCOVERY_NAME = DEFAULT_NAME
+
+    def discovery_name
+      @discovery_name || DEFAULT_DISCOVERY_NAME
+    end
 
     def model_name
       @model_name || DEFAULT_MODEL_NAME
@@ -22,7 +28,7 @@ module RubyHome
       @bind || DEFAULT_BIND
     end
 
-    attr_writer :model_name, :bind, :port
+    attr_writer :discovery_name, :model_name,:bind, :port
 
     def_delegators :@accessory_info, :password, :password=
   end

--- a/lib/ruby_home/configuration.rb
+++ b/lib/ruby_home/configuration.rb
@@ -6,13 +6,18 @@ module RubyHome
       @accessory_info = accessory_info
     end
 
+    DEFAULT_BIND = -'0.0.0.0'
     DEFAULT_PORT = 4567
 
     def port
       @port || DEFAULT_PORT
     end
 
-    attr_writer :port
+    def bind
+      @bind || DEFAULT_BIND
+    end
+
+    attr_writer :bind, :port
 
     def_delegators :@accessory_info, :model_name, :model_name=
     def_delegators :@accessory_info, :password, :password=

--- a/lib/ruby_home/configuration.rb
+++ b/lib/ruby_home/configuration.rb
@@ -7,5 +7,6 @@ module RubyHome
     end
 
     def_delegators :@accessory_info, :model_name, :model_name=
+    def_delegators :@accessory_info, :password, :password=
   end
 end

--- a/lib/ruby_home/configuration.rb
+++ b/lib/ruby_home/configuration.rb
@@ -7,7 +7,7 @@ module RubyHome
     end
 
     DEFAULT_NAME = -'RubyHome'
-    DEFAULT_BIND = -'0.0.0.0'
+    DEFAULT_HOST = -'0.0.0.0'
     DEFAULT_PORT = 4567
     DEFAULT_MODEL_NAME = DEFAULT_NAME
     DEFAULT_DISCOVERY_NAME = DEFAULT_NAME
@@ -24,11 +24,11 @@ module RubyHome
       @port || DEFAULT_PORT
     end
 
-    def bind
-      @bind || DEFAULT_BIND
+    def host
+      @host || DEFAULT_HOST
     end
 
-    attr_writer :discovery_name, :model_name,:bind, :port
+    attr_writer :discovery_name, :model_name, :host, :port
 
     def_delegators :@accessory_info, :password, :password=
   end

--- a/lib/ruby_home/configuration.rb
+++ b/lib/ruby_home/configuration.rb
@@ -8,6 +8,11 @@ module RubyHome
 
     DEFAULT_BIND = -'0.0.0.0'
     DEFAULT_PORT = 4567
+    DEFAULT_MODEL_NAME = -'RubyHome'
+
+    def model_name
+      @model_name || DEFAULT_MODEL_NAME
+    end
 
     def port
       @port || DEFAULT_PORT
@@ -17,9 +22,8 @@ module RubyHome
       @bind || DEFAULT_BIND
     end
 
-    attr_writer :bind, :port
+    attr_writer :model_name, :bind, :port
 
-    def_delegators :@accessory_info, :model_name, :model_name=
     def_delegators :@accessory_info, :password, :password=
   end
 end

--- a/lib/ruby_home/configuration.rb
+++ b/lib/ruby_home/configuration.rb
@@ -1,0 +1,11 @@
+module RubyHome
+  class Configuration
+    extend Forwardable
+
+    def initialize(accessory_info = AccessoryInfo.instance)
+      @accessory_info = accessory_info
+    end
+
+    def_delegators :@accessory_info, :model_name, :model_name=
+  end
+end

--- a/lib/ruby_home/configuration.rb
+++ b/lib/ruby_home/configuration.rb
@@ -6,6 +6,14 @@ module RubyHome
       @accessory_info = accessory_info
     end
 
+    DEFAULT_PORT = 4567
+
+    def port
+      @port || DEFAULT_PORT
+    end
+
+    attr_writer :port
+
     def_delegators :@accessory_info, :model_name, :model_name=
     def_delegators :@accessory_info, :password, :password=
   end

--- a/lib/ruby_home/dns/service.rb
+++ b/lib/ruby_home/dns/service.rb
@@ -19,7 +19,7 @@ module RubyHome
 
       def dnssd_service
         @_dnssd_service ||= begin
-          DNSSD::Service.register(name, type, nil, port, nil, text_record)
+          DNSSD::Service.register(name, type, nil, port, host, text_record)
         end
       end
 
@@ -28,11 +28,17 @@ module RubyHome
       end
 
       def type
-        '_hap._tcp'
+        -'_hap._tcp'
       end
 
       def port
         configuration.port
+      end
+
+      def host
+        return nil if configuration.host == Configuration::DEFAULT_HOST
+
+        configuration.host
       end
 
       def text_record

--- a/lib/ruby_home/dns/service.rb
+++ b/lib/ruby_home/dns/service.rb
@@ -22,7 +22,7 @@ module RubyHome
       end
 
       def name
-        'RubyHome'
+        accessory_info.model_name
       end
 
       def type
@@ -32,7 +32,11 @@ module RubyHome
       attr_reader :port
 
       def text_record
-        TextRecord.new(accessory_info: AccessoryInfo.instance)
+        TextRecord.new(accessory_info: accessory_info)
+      end
+
+      def accessory_info
+        AccessoryInfo.instance
       end
     end
   end

--- a/lib/ruby_home/dns/service.rb
+++ b/lib/ruby_home/dns/service.rb
@@ -24,7 +24,7 @@ module RubyHome
       end
 
       def name
-        configuration.model_name
+        configuration.discovery_name
       end
 
       def type

--- a/lib/ruby_home/dns/service.rb
+++ b/lib/ruby_home/dns/service.rb
@@ -1,8 +1,8 @@
 module RubyHome
   module DNS
     class Service
-      def initialize(port)
-        @port = port
+      def initialize(configuration: )
+        @configuration = configuration
       end
 
       def update
@@ -15,6 +15,8 @@ module RubyHome
 
       private
 
+      attr_reader :configuration
+
       def dnssd_service
         @_dnssd_service ||= begin
           DNSSD::Service.register(name, type, nil, port, nil, text_record)
@@ -22,17 +24,19 @@ module RubyHome
       end
 
       def name
-        accessory_info.model_name
+        configuration.model_name
       end
 
       def type
         '_hap._tcp'
       end
 
-      attr_reader :port
+      def port
+        configuration.port
+      end
 
       def text_record
-        TextRecord.new(accessory_info: accessory_info)
+        TextRecord.new(accessory_info: accessory_info, configuration: configuration)
       end
 
       def accessory_info

--- a/lib/ruby_home/dns/text_record.rb
+++ b/lib/ruby_home/dns/text_record.rb
@@ -74,7 +74,7 @@ module RubyHome
     # Model name of the accessory (e.g. "Device1,1"). Required.
 
     def model_name
-      'RubyHome'
+      accessory_info.model_name
     end
 
     # Protocol version string <major>.<minor> (e.g. "1.0"). Required if value is

--- a/lib/ruby_home/dns/text_record.rb
+++ b/lib/ruby_home/dns/text_record.rb
@@ -1,13 +1,14 @@
 module RubyHome
   class TextRecord < DNSSD::TextRecord
-    def initialize(accessory_info:)
+    def initialize(accessory_info:, configuration:)
+      @configuration = configuration
       @accessory_info = accessory_info
       super(to_hash)
     end
 
     private
 
-    attr_reader :accessory_info
+    attr_reader :accessory_info, :configuration
 
     def to_hash
       {
@@ -74,7 +75,7 @@ module RubyHome
     # Model name of the accessory (e.g. "Device1,1"). Required.
 
     def model_name
-      accessory_info.model_name
+      configuration.model_name
     end
 
     # Protocol version string <major>.<minor> (e.g. "1.0"). Required if value is

--- a/lib/ruby_home/version.rb
+++ b/lib/ruby_home/version.rb
@@ -1,3 +1,3 @@
 module RubyHome
-  VERSION = '0.1.21'
+  VERSION = '0.1.22'
 end

--- a/spec/lib/accessory_info_spec.rb
+++ b/spec/lib/accessory_info_spec.rb
@@ -15,6 +15,17 @@ RSpec.describe RubyHome::AccessoryInfo do
     end
   end
 
+  describe '#model_name' do
+    it 'returns RubyHome by default' do
+      expect(instance.model_name).to eql('RubyHome')
+    end
+
+    it 'returns customised model_name if it\'s been set' do
+      instance.model_name = 'Custom Model Name'
+      expect(instance.model_name).to eql('Custom Model Name')
+    end
+  end
+
   describe '#signing_key' do
     it 'returns a Ed25519::SigningKey' do
       expect(instance.signing_key).to be_a(RbNaCl::Signatures::Ed25519::SigningKey)

--- a/spec/lib/accessory_info_spec.rb
+++ b/spec/lib/accessory_info_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe RubyHome::AccessoryInfo do
     it 'returns 031-45-154' do
       expect(instance.password).to eql('031-45-154')
     end
+
+    it 'returns customised password if it\'s been set' do
+      instance.password = '999-66-333'
+      expect(instance.password).to eql('999-66-333')
+    end
+
+    it 'persists customised password' do
+      instance.password = '999-66-333'
+      instance.reload
+
+      expect(RubyHome::AccessoryInfo.persisted.password).to eql('999-66-333')
+    end
   end
 
   describe '#model_name' do

--- a/spec/lib/accessory_info_spec.rb
+++ b/spec/lib/accessory_info_spec.rb
@@ -27,17 +27,6 @@ RSpec.describe RubyHome::AccessoryInfo do
     end
   end
 
-  describe '#model_name' do
-    it 'returns RubyHome by default' do
-      expect(instance.model_name).to eql('RubyHome')
-    end
-
-    it 'returns customised model_name if it\'s been set' do
-      instance.model_name = 'Custom Model Name'
-      expect(instance.model_name).to eql('Custom Model Name')
-    end
-  end
-
   describe '#signing_key' do
     it 'returns a Ed25519::SigningKey' do
       expect(instance.signing_key).to be_a(RbNaCl::Signatures::Ed25519::SigningKey)

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -38,4 +38,15 @@ RSpec.describe RubyHome::Configuration do
       expect(configuration.port).to eql(8080)
     end
   end
+
+  describe "#bind" do
+    it 'defaults to 0.0.0.0' do
+      expect(configuration.bind).to eql('0.0.0.0')
+    end
+
+    it 'allows configuration of bind' do
+      configuration.bind = '127.0.0.1'
+      expect(configuration.bind).to eql('127.0.0.1')
+    end
+  end
 end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -49,14 +49,14 @@ RSpec.describe RubyHome::Configuration do
     end
   end
 
-  describe "#bind" do
+  describe "#host" do
     it 'defaults to 0.0.0.0' do
-      expect(configuration.bind).to eql('0.0.0.0')
+      expect(configuration.host).to eql('0.0.0.0')
     end
 
-    it 'allows configuration of bind' do
-      configuration.bind = '127.0.0.1'
-      expect(configuration.bind).to eql('127.0.0.1')
+    it 'allows configuration of host' do
+      configuration.host = '127.0.0.1'
+      expect(configuration.host).to eql('127.0.0.1')
     end
   end
 end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -4,23 +4,27 @@ RSpec.describe RubyHome::Configuration do
   let(:accessory_info) { RubyHome::AccessoryInfo.instance }
   subject(:configuration) { described_class.new }
 
-  it 'allows configuration of model_name' do
-    configuration.model_name = 'Custom Model Name'
-    expect(configuration.model_name).to eql('Custom Model Name')
+  describe '#model_name' do
+    it 'allows configuration of model_name' do
+      configuration.model_name = 'Custom Model Name'
+      expect(configuration.model_name).to eql('Custom Model Name')
+    end
+
+    it 'sets model_name within accessory info' do
+      configuration.model_name = 'Custom Model Name'
+      expect(accessory_info.model_name).to eql('Custom Model Name')
+    end
   end
 
-  it 'sets model_name within accessory info' do
-    configuration.model_name = 'Custom Model Name'
-    expect(accessory_info.model_name).to eql('Custom Model Name')
-  end
+  describe "#password" do
+    it 'allows configuration of password' do
+      configuration.password = '031-45-154'
+      expect(configuration.password).to eql('031-45-154')
+    end
 
-  it 'allows configuration of password' do
-    configuration.password = '031-45-154'
-    expect(configuration.password).to eql('031-45-154')
-  end
-
-  it 'sets password within accessory info' do
-    configuration.password = '031-45-154'
-    expect(accessory_info.password).to eql('031-45-154')
+    it 'sets password within accessory info' do
+      configuration.password = '031-45-154'
+      expect(accessory_info.password).to eql('031-45-154')
+    end
   end
 end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -13,4 +13,14 @@ RSpec.describe RubyHome::Configuration do
     configuration.model_name = 'Custom Model Name'
     expect(accessory_info.model_name).to eql('Custom Model Name')
   end
+
+  it 'allows configuration of password' do
+    configuration.password = '031-45-154'
+    expect(configuration.password).to eql('031-45-154')
+  end
+
+  it 'sets password within accessory info' do
+    configuration.password = '031-45-154'
+    expect(accessory_info.password).to eql('031-45-154')
+  end
 end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -5,14 +5,13 @@ RSpec.describe RubyHome::Configuration do
   subject(:configuration) { described_class.new }
 
   describe '#model_name' do
+    it 'defaults to RubyHome' do
+      expect(configuration.model_name).to eql('RubyHome')
+    end
+
     it 'allows configuration of model_name' do
       configuration.model_name = 'Custom Model Name'
       expect(configuration.model_name).to eql('Custom Model Name')
-    end
-
-    it 'sets model_name within accessory info' do
-      configuration.model_name = 'Custom Model Name'
-      expect(accessory_info.model_name).to eql('Custom Model Name')
     end
   end
 

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe RubyHome::Configuration do
+  let(:accessory_info) { RubyHome::AccessoryInfo.instance }
+  subject(:configuration) { described_class.new }
+
+  it 'allows configuration of model_name' do
+    configuration.model_name = 'Custom Model Name'
+    expect(configuration.model_name).to eql('Custom Model Name')
+  end
+
+  it 'sets model_name within accessory info' do
+    configuration.model_name = 'Custom Model Name'
+    expect(accessory_info.model_name).to eql('Custom Model Name')
+  end
+end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -4,14 +4,25 @@ RSpec.describe RubyHome::Configuration do
   let(:accessory_info) { RubyHome::AccessoryInfo.instance }
   subject(:configuration) { described_class.new }
 
+  describe '#discovery_name' do
+    it 'defaults to RubyHome' do
+      expect(configuration.discovery_name).to eql('RubyHome')
+    end
+
+    it 'allows configuration of discovery_name' do
+      configuration.discovery_name = 'Custom Model Name'
+      expect(configuration.discovery_name).to eql('Custom Model Name')
+    end
+  end
+
   describe '#model_name' do
     it 'defaults to RubyHome' do
       expect(configuration.model_name).to eql('RubyHome')
     end
 
     it 'allows configuration of model_name' do
-      configuration.model_name = 'Custom Model Name'
-      expect(configuration.model_name).to eql('Custom Model Name')
+      configuration.model_name = 'Device1,1'
+      expect(configuration.model_name).to eql('Device1,1')
     end
   end
 

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -27,4 +27,15 @@ RSpec.describe RubyHome::Configuration do
       expect(accessory_info.password).to eql('031-45-154')
     end
   end
+
+  describe '#port' do
+    it 'defaults to 4567' do
+      expect(configuration.port).to eql(4567)
+    end
+
+    it 'allows configuration of port' do
+      configuration.port = 8080
+      expect(configuration.port).to eql(8080)
+    end
+  end
 end


### PR DESCRIPTION
Closes #56

Allow configuration of certain settings within RubyHome

For example:

```ruby
RubyHome.configure do |c|
  c.discovery_name = 'My House'
  c.model_name = 'Device1,1'
  c.password = '101-48-005'
  c.host = '192.168.0.2'
  c.port = 8080
end
```