### PR TITLE
Add support for devices with MinimumValue/MaximumValue/StepValue constraints

### DIFF
--- a/lib/ruby_home/errors.rb
+++ b/lib/ruby_home/errors.rb
@@ -1,0 +1,4 @@
+module RubyHome
+  class RubyHomeError < StandardError; end
+  class UnknownValueError < RubyHomeError; end
+end

--- a/lib/ruby_home/hap/values/uint8_value.rb
+++ b/lib/ruby_home/hap/values/uint8_value.rb
@@ -13,7 +13,24 @@ module RubyHome
       end
 
       def valid_values
-        template.constraints.fetch('ValidValues')
+        defined_values || range_values
+      end
+
+      def defined_values
+        template.constraints.dig('ValidValues')
+      end
+
+      def range_values
+        values = {}
+        min = template.constraints.dig('MinimumValue')
+        max = template.constraints.dig('MaximumValue')
+        step = template.constraints.dig('StepValue')
+
+        (min..max).step(step) do |n|
+          values[n.to_s] = n.to_s
+        end
+
+        values
       end
   end
 end

--- a/lib/ruby_home/hap/values/uint8_value.rb
+++ b/lib/ruby_home/hap/values/uint8_value.rb
@@ -13,7 +13,7 @@ module RubyHome
       end
 
       def valid_values
-        defined_values || range_values
+        defined_values || range_values || raise(UnknownValueError, "Constraint contains an unrecognized list of values: #{template.constraints.inspect }")
       end
 
       def defined_values
@@ -21,16 +21,9 @@ module RubyHome
       end
 
       def range_values
-        values = {}
-        min = template.constraints.dig('MinimumValue')
-        max = template.constraints.dig('MaximumValue')
-        step = template.constraints.dig('StepValue')
-
-        (min..max).step(step) do |n|
-          values[n.to_s] = n.to_s
+        if min = template.constraints.dig('MinimumValue')
+          { min.to_s => min }
         end
-
-        values
       end
   end
 end

--- a/lib/ruby_home/version.rb
+++ b/lib/ruby_home/version.rb
@@ -1,3 +1,3 @@
 module RubyHome
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/spec/lib/hap/values/uint8_value_spec.rb
+++ b/spec/lib/hap/values/uint8_value_spec.rb
@@ -2,10 +2,28 @@ require 'spec_helper'
 
 RSpec.describe RubyHome::Uint8Value do
   describe '#default' do
-    it 'returns first default value from valid values' do
-      template = double(constraints: { 'ValidValues' => { '0' => 'Inactive' } } )
-      handler = RubyHome::Uint8Value.new(template)
-      expect(handler.default).to eql(0)
+    context 'unit nil' do
+      it 'returns first default value from ValidValues' do
+        template = double(constraints: { 'ValidValues' => { '0' => 'Inactive' } } )
+        handler = RubyHome::Uint8Value.new(template)
+        expect(handler.default).to eql(0)
+      end
+    end
+
+    context 'unit percentage' do
+      it 'returns first default value MinimumValue' do
+        template = double(constraints: { 'MaximumValue' => 100, 'MinimumValue' => 0, 'StepValue' => 1} )
+        handler = RubyHome::Uint8Value.new(template)
+        expect(handler.default).to eql(0)
+      end
+    end
+
+    context 'unit unknown' do
+      it 'raises an error' do
+        template = double(constraints: { 'UnknownValue' => 0 } )
+        handler = RubyHome::Uint8Value.new(template)
+        expect { handler.default }.to raise_error(RubyHome::UnknownValueError)
+      end
     end
   end
 end


### PR DESCRIPTION
First off let me just say that I LOVE THIS GEM. I went from having no idea how to get my own devices on Homekit, to having an actual device on Homekit in the span of a couple of hours. Thank you!!

The only hiccup I came across was trying to add a Window Covering. I was getting this error:

```
2019-06-06 14:18:34 - KeyError - key not found: "ValidValues":
	/Users/rob/.gem/ruby/2.5.1/gems/ruby_home-0.2.0/lib/ruby_home/hap/values/uint8_value.rb:16:in `fetch'
	/Users/rob/.gem/ruby/2.5.1/gems/ruby_home-0.2.0/lib/ruby_home/hap/values/uint8_value.rb:16:in `valid_values'
	/Users/rob/.gem/ruby/2.5.1/gems/ruby_home-0.2.0/lib/ruby_home/hap/values/uint8_value.rb:12:in `first_default_value'
	/Users/rob/.gem/ruby/2.5.1/gems/ruby_home-0.2.0/lib/ruby_home/hap/values/uint8_value.rb:6:in `default'
	/Users/rob/.gem/ruby/2.5.1/gems/ruby_home-0.2.0/lib/ruby_home/hap/values/base_value.rb:17:in `value'
	/Users/rob/.gem/ruby/2.5.1/gems/ruby_home-0.2.0/lib/ruby_home/characteristic.rb:78:in `value'
	/Users/rob/.gem/ruby/2.5.1/gems/ruby_home-0.2.0/lib/ruby_home/http/serializers/characteristic_serializer.rb:34:in `value_hash'
	/Users/rob/.gem/ruby/2.5.1/gems/ruby_home-0.2.0/lib/ruby_home/http/serializers/characteristic_serializer.rb:17:in `record_hash'
	/Users/rob/.gem/ruby/2.5.1/gems/ruby_home-0.2.0/lib/ruby_home/http/serializers/object_serializer.rb:23:in `block in serializable_hash'
	/Users/rob/.gem/ruby/2.5.1/gems/ruby_home-0.2.0/lib/ruby_home/characteristic_collection.rb:10:in `each'
	/Users/rob/.gem/ruby/2.5.1/gems/ruby_home-0.2.0/lib/ruby_home/characteristic_collection.rb:10:in `each'
```

I did some digging and found that when adding a device like a Fan, the constraints will look something like:

```ruby
{"ValidValues"=>{"0"=>"Open", "1"=>"Closed", "2"=>"Opening", "3"=>"Closing", "4"=>"Stopped"}}
```

But the constraints for Window Covering look like:

```ruby
{"MaximumValue"=>100, "MinimumValue"=>0, "StepValue"=>1}
```

So I tweaked the `valid_values` method to first try `ValidValues` and if that returns `nil` then look for `MiniumumValue` and `MaximumValue` and create the same type of hash where the key is the valid value (every value between `MiniumumValue` and `MaximumValue` by `StepValue`):

```ruby
{"0"=>"0", "1"=>"1", "2"=>"2", "3"=>"3", "4"=>"4", "5"=>"5", "6"=>"6", "7"=>"7", "8"=>"8", "9"=>"9", "10"=>"10", "11"=>"11", "12"=>"12", "13"=>"13", "14"=>"14", "15"=>"15", "16"=>"16", "17"=>"17", "18"=>"18", "19"=>"19", "20"=>"20", "21"=>"21", "22"=>"22", "23"=>"23", "24"=>"24", "25"=>"25", "26"=>"26", "27"=>"27", "28"=>"28", "29"=>"29", "30"=>"30", "31"=>"31", "32"=>"32", "33"=>"33", "34"=>"34", "35"=>"35", "36"=>"36", "37"=>"37", "38"=>"38", "39"=>"39", "40"=>"40", "41"=>"41", "42"=>"42", "43"=>"43", "44"=>"44", "45"=>"45", "46"=>"46", "47"=>"47", "48"=>"48", "49"=>"49", "50"=>"50", "51"=>"51", "52"=>"52", "53"=>"53", "54"=>"54", "55"=>"55", "56"=>"56", "57"=>"57", "58"=>"58", "59"=>"59", "60"=>"60", "61"=>"61", "62"=>"62", "63"=>"63", "64"=>"64", "65"=>"65", "66"=>"66", "67"=>"67", "68"=>"68", "69"=>"69", "70"=>"70", "71"=>"71", "72"=>"72", "73"=>"73", "74"=>"74", "75"=>"75", "76"=>"76", "77"=>"77", "78"=>"78", "79"=>"79", "80"=>"80", "81"=>"81", "82"=>"82", "83"=>"83", "84"=>"84", "85"=>"85", "86"=>"86", "87"=>"87", "88"=>"88", "89"=>"89", "90"=>"90", "91"=>"91", "92"=>"92", "93"=>"93", "94"=>"94", "95"=>"95", "96"=>"96", "97"=>"97", "98"=>"98", "99"=>"99", "100"=>"100"}
```

And then the code that comes after that can behave as before—pull the first key and convert it to an integer and return it as the default value.

If there is a third kind of Value constraint that we don't know about yet this will blow up again. Let me know if you'd like me to make it a little more foolproof (maybe raise a custom error if neither `ValidValue` or `MinimumValue` are found in the constraint?)