### PR TITLE
Add support for Ruby 2.7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,10 @@ install:
   - 'bundle --version'
   - bundle
 rvm:
-  - 2.4.1
+  - 2.4
   - 2.5
   - 2.6
+  - 2.7
   - ruby-head
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
-  - ruby-head
 os:
   - linux
   - osx


### PR DESCRIPTION
Steps taken to support Ruby 2.7:

- Added an automated check within Travis to test compatibility going forward