### PR TITLE
Fix tests on Ruby 2.8

### DIFF
--- a/lib/ruby_home/factories/templates/characteristic_template.rb
+++ b/lib/ruby_home/factories/templates/characteristic_template.rb
@@ -4,7 +4,7 @@ module RubyHome
     DATA = YAML.load_file(FILEPATH).freeze
 
     def self.all
-      @@all ||= DATA.map { |data| new(data) }
+      @@all ||= DATA.map { |data| new(**data) }
     end
 
     def self.find_by(options)

--- a/lib/ruby_home/factories/templates/service_template.rb
+++ b/lib/ruby_home/factories/templates/service_template.rb
@@ -4,7 +4,7 @@ module RubyHome
     DATA = YAML.load_file(FILEPATH).freeze
 
     def self.all
-      @all ||= DATA.map { |data| new(data) }
+      @all ||= DATA.map { |data| new(**data) }
     end
 
     def self.find_by(options)

--- a/lib/ruby_home/http/controllers/pair_setups_controller.rb
+++ b/lib/ruby_home/http/controllers/pair_setups_controller.rb
@@ -96,7 +96,7 @@ module RubyHome
           encrypted_data = chacha20poly1305ietf.encrypt(nonce, subtlv)
 
           pairing_params = { admin: true, identifier: iosdevicepairingid, public_key: iosdeviceltpk.unpack1('H*') }
-          accessory_info.add_paired_client pairing_params
+          accessory_info.add_paired_client(**pairing_params)
 
           tlv state: 6, encrypted_data: encrypted_data
         end

--- a/lib/ruby_home/http/controllers/pairings_controller.rb
+++ b/lib/ruby_home/http/controllers/pairings_controller.rb
@@ -22,7 +22,7 @@ module RubyHome
           identifier: unpack_request[:identifier],
           public_key: unpack_request[:public_key].unpack1('H*')
         }
-        accessory_info.add_paired_client pairing_params
+        accessory_info.add_paired_client(**pairing_params)
 
         tlv state: 2
       end

--- a/lib/ruby_home/persistable.rb
+++ b/lib/ruby_home/persistable.rb
@@ -10,7 +10,7 @@ module RubyHome
     module ClassMethods
       def persisted
         if yaml = read
-          new(yaml)
+          new(**yaml)
         end
       end
 

--- a/spec/http/requests/identify_spec.rb
+++ b/spec/http/requests/identify_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe '/identify' do
   context 'POST' do
     context 'Request denied due to accessory being paired' do
       before do
-        RubyHome::AccessoryInfo.instance.add_paired_client({
+        RubyHome::AccessoryInfo.instance.add_paired_client(
           admin: true,
           identifier: '349CBC7D-01B9-4DC4-AD98-FB9029BB77F2',
           public_key: '8d9686b698958af1497694003e07ff855358619f9633d62e40a6b55952716f17'
-        })
+        )
       end
 
       it 'response headers contains application/hap+json' do

--- a/spec/http/requests/pairings_spec.rb
+++ b/spec/http/requests/pairings_spec.rb
@@ -29,11 +29,11 @@ RSpec.describe 'POST /pairings' do
 
   context 'Remove Pairing Response' do
     before do
-      RubyHome::AccessoryInfo.instance.add_paired_client({
+      RubyHome::AccessoryInfo.instance.add_paired_client(
         admin: true,
         identifier: '349CBC7D-01B9-4DC4-AD98-FB9029BB77F2',
         public_key: '8d9686b698958af1497694003e07ff855358619f9633d62e40a6b55952716f17'
-      })
+      )
       path = File.expand_path('../../../fixtures/remove_pairing_request', __FILE__)
       data = File.read(path)
       post '/pairings', data, {'CONTENT_TYPE' => 'application/pairing+tlv8'}

--- a/spec/lib/accessory_info_spec.rb
+++ b/spec/lib/accessory_info_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe RubyHome::AccessoryInfo do
 
     context 'has paired clients' do
       it 'returns true' do
-        instance.add_paired_client({identifier: double, public_key: double})
+        instance.add_paired_client(identifier: double, public_key: double)
         expect(instance).to be_paired
       end
     end
@@ -64,7 +64,7 @@ RSpec.describe RubyHome::AccessoryInfo do
     it 'adds a client to paired_clients' do
       public_key = 'public_key'
       identifier = 'identifier'
-      instance.add_paired_client({identifier: identifier, public_key: public_key})
+      instance.add_paired_client(identifier: identifier, public_key: public_key)
       expect(instance.paired_clients).to match(
         a_hash_including(
           admin: false,


### PR DESCRIPTION
This commit just fixes tests on Ruby 2.8.  Mainly the issue is to do
with keyword arguments.  Ruby 2.8 is more strict about keyword
arguments, and we either need to splat hashes in to kwargs, or just call
the methods with kwargs.