### PR TITLE
Update CI to test against Ruby 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - ruby-head
 os:
   - linux
   - osx


### PR DESCRIPTION
Update the CI server to check RubyHome works with Ruby 2.8.