### PR TITLE
Fix Ruby 2.8 warning message

### DIFF
--- a/lib/ruby_home/persistable.rb
+++ b/lib/ruby_home/persistable.rb
@@ -23,7 +23,7 @@ module RubyHome
       end
 
       def read
-        return false unless File.exists?(source)
+        return false unless File.exist?(source)
 
         YAML.load_file(source)
       end


### PR DESCRIPTION
```
warning: File.exists? is deprecated; use File.exist? instead
```