### PR TITLE
Switch CI from tracking ruby-head to ruby 2.8.0-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
-  - 2.8.0
+  - 2.8
 os:
   - linux
   - osx
@@ -30,4 +30,4 @@ notifications:
   email: false
 jobs:
   allow_failures:
-  - rvm: 2.8.0
+  - rvm: 2.8


### PR DESCRIPTION
Here we are switching the RVM build from tracking ruby-head to Ruby 2.8.0-dev. This is because we are interested if the gem is compatible with Ruby 2.8 so we should explicitly track it.

This is also allowed to fail for now by being part of `allow_failures` but in a subsequent PR will be required to pass.