### PR TITLE
Fix Ruby 3.0 LoadError: cannot load such file -- webrick

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.7, 2.6, 2.5]
+        ruby-version: [3.0, 2.7, 2.6, 2.5]
     steps:
     - name: Install libdnssd
       run: sudo apt-get install libavahi-compat-libdnssd-dev
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        ruby-version: [2.7, 2.6, 2.5]
+        ruby-version: [3.0, 2.7, 2.6, 2.5]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/rubyhome.gemspec
+++ b/rubyhome.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ruby_home-srp', '~> 1.3'
   spec.add_dependency 'ruby_home-tlv', '~> 0.1'
   spec.add_dependency 'sinatra', '~> 2.0'
+  spec.add_dependency 'webrick', '~> 1.7'
   spec.add_dependency 'wisper', '~> 2.0'
 
   spec.add_development_dependency 'byebug', '~> 11.0'


### PR DESCRIPTION
webrick is no longer a bundled gem or standard library. Install the corresponding gems to continue using webrick.