### PR TITLE
Migrate to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/c81f4cfdf5c13d716487/maintainability)](https://codeclimate.com/github/karlentwistle/ruby_home/maintainability)
-[![Build Status](https://travis-ci.org/karlentwistle/ruby_home.svg?branch=master)](https://travis-ci.org/karlentwistle/ruby_home)
+[![Build Status](https://www.travis-ci.com/karlentwistle/ruby_home.svg?branch=master)](https://www.travis-ci.com/karlentwistle/ruby_home)
 
 # ruby_home
 


### PR DESCRIPTION
Mostly just wanted to check that the automatic checks are using https://travis-ci.com/ instead of https://travis-ci.org/ which is apparently shutting down in several weeks.