### PR TITLE
Improve test suite reliability

### DIFF
--- a/lib/ruby_home/accessory_info.rb
+++ b/lib/ruby_home/accessory_info.rb
@@ -10,10 +10,6 @@ module RubyHome
       @@_instance ||= persisted || create
     end
 
-    def self.reload
-      @@_instance = nil
-    end
-
     USERNAME = -'Pair-Setup'
 
     def initialize(device_id: nil, paired_clients: [], password: nil, signature_key: nil)

--- a/lib/ruby_home/persistable.rb
+++ b/lib/ruby_home/persistable.rb
@@ -19,15 +19,17 @@ module RubyHome
       end
 
       def write(collection)
-        File.open(source, 'w') {|f| f.write(collection.to_yaml) }
+        source.rewind
+        source.write(collection.to_yaml)
       end
 
       def read
-        return false unless File.exist?(source)
+        source.rewind
+        YAML.load(source.read)
+      end
 
-        YAML.load_file(source)
-      rescue Errno::EBADF
-        return false
+      def reload
+        self.class_variable_set(:@@_instance, nil)
       end
     end
 

--- a/spec/lib/persistable_spec.rb
+++ b/spec/lib/persistable_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+RSpec.describe RubyHome::Persistable do
+  class TestPersistable
+    include RubyHome::Persistable
+
+    def initialize(attributes)
+      @attributes = attributes
+    end
+
+    attr_reader :attributes
+
+    alias persisted_attributes attributes
+
+    def ==(other)
+      self.attributes == other.attributes
+    end
+  end
+
+  describe '#save' do
+    it 'writes persisted_attributes to file' do
+      tempfile = Tempfile.new
+      TestPersistable.source = tempfile
+
+      TestPersistable.new({
+        attribute_a: "attribute a value",
+        attribute_b: "attribute b value"
+      }).save
+
+      tempfile.rewind
+      expect(tempfile.read).to eql(
+        <<~EXPECTED_RESULT
+          ---
+          :attribute_a: attribute a value
+          :attribute_b: attribute b value
+        EXPECTED_RESULT
+      )
+    end
+  end
+
+  describe '.persisted' do
+    it 'reads attributes from file an initializes new class' do
+      tempfile = Tempfile.new
+      tempfile.write(
+        <<~EXPECTED_RESULT
+          ---
+          :attribute_a: attribute a value
+          :attribute_b: attribute b value
+        EXPECTED_RESULT
+      )
+      TestPersistable.source = tempfile
+
+      expect(TestPersistable.persisted).to eq(
+        TestPersistable.new(
+          attribute_a: 'attribute a value',
+          attribute_b: 'attribute b value'
+        )
+      )
+    end
+  end
+end

--- a/spec/support/accessory_info.rb
+++ b/spec/support/accessory_info.rb
@@ -6,7 +6,7 @@ EXAMPLE_SIGNATURE_KEY = -'E2889D17DD141C3A62969E85C7092FDB1080617FECCC08A60A5001
 RSpec.configure do |config|
   config.around(:each) do |example|
     begin
-      tempfile = Tempfile.new('accessory_info.yml')
+      tempfile = StringIO.new
       RubyHome::AccessoryInfo.source = tempfile
       RubyHome::AccessoryInfo.reload
       RubyHome::AccessoryInfo.create(
@@ -18,7 +18,6 @@ RSpec.configure do |config|
       example.run
     ensure
       tempfile.close
-      tempfile.unlink
     end
   end
 end

--- a/spec/support/identifier_cache.rb
+++ b/spec/support/identifier_cache.rb
@@ -1,12 +1,11 @@
 RSpec.configure do |config|
   config.around(:each) do |example|
     begin
-      tempfile = Tempfile.new('identifier_cache.yml')
+      tempfile = StringIO.new
       RubyHome::IdentifierCache.source = tempfile
       example.run
     ensure
       tempfile.close
-      tempfile.unlink
     end
   end
 end


### PR DESCRIPTION
This should improve the reliability of the test suite. Before this change, it would indeterminately fail with `Bad file descriptor fptr_finalize_flush`. I've switched from using `Tempfile` to `StringIO` object for most tests in the test suite. To ensure `Persistable` still works with a file object I have introduced two specific unit tests for `Persistable` that continue to use a `Tempfile`.

This should make the test suite run faster since `StringIO` is held in memory but `Tempfile` is persisted to disc meaning the test suite was doing many disc read and write operations.