### PR TITLE
Improve test suite reliability

### DIFF
--- a/lib/ruby_home/persistable.rb
+++ b/lib/ruby_home/persistable.rb
@@ -19,7 +19,11 @@ module RubyHome
       end
 
       def write(collection)
-        File.open(source, 'w') {|f| f.write(collection.to_yaml) }
+        File.open(source, 'w') do |file|
+          file.write(collection.to_yaml)
+        end
+      rescue Errno::EBADF
+        false
       end
 
       def read


### PR DESCRIPTION
This should improve the reliability of the test suite. Before this change, it would indeterminately fail with errors like

```
Errno::EBADF:

Bad file descriptor @ fptr_finalize_flush - /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/identifier_cache.yml20210502-3901-1ob73tl
```

This is due to the file being unwritable. Instead of raising an exception, we should return `false` to signal the file hasn't been written.