### PR TITLE
Remove Ruby 2.5 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [3.0, 2.7, 2.6, 2.5]
+        ruby-version: [3.0, 2.7, 2.6]
     steps:
     - name: Install libdnssd
       run: sudo apt-get install libavahi-compat-libdnssd-dev


### PR DESCRIPTION
Ruby 2.5 is now EOL so we can remove support