### PR TITLE
Expose maximum/minimum/step values of a numeric characteristics

### DIFF
--- a/lib/ruby_home/characteristic.rb
+++ b/lib/ruby_home/characteristic.rb
@@ -73,24 +73,24 @@ module RubyHome
     end
 
     def minimum_value
-      return unless format_numeric?
+      return unless numeric_format?
 
       constraints["MinimumValue"]
     end
 
     def maximum_value
-      return unless format_numeric?
+      return unless numeric_format?
 
       constraints["MaximumValue"]
     end
 
     def step_value
-      return unless format_numeric?
+      return unless numeric_format?
 
       constraints["StepValue"]
     end
 
-    def format_numeric?
+    def numeric_format?
       format == "uint32" || format == "float"
     end
 

--- a/lib/ruby_home/characteristic.rb
+++ b/lib/ruby_home/characteristic.rb
@@ -73,24 +73,24 @@ module RubyHome
     end
 
     def minimum_value
-      return unless numeric_constraints?
+      return unless format_numeric?
 
       constraints["MinimumValue"]
     end
 
     def maximum_value
-      return unless numeric_constraints?
+      return unless format_numeric?
 
       constraints["MaximumValue"]
     end
 
     def step_value
-      return unless numeric_constraints?
+      return unless format_numeric?
 
       constraints["StepValue"]
     end
 
-    def numeric_constraints?
+    def format_numeric?
       format == "uint32" || format == "float"
     end
 

--- a/lib/ruby_home/characteristic.rb
+++ b/lib/ruby_home/characteristic.rb
@@ -90,8 +90,10 @@ module RubyHome
       constraints["StepValue"]
     end
 
+    NUMERIC_FORMATS = ["float", "uint8", "int32", "uint32"].freeze
+
     def numeric_format?
-      format == "uint32" || format == "float"
+      NUMERIC_FORMATS.include?(format)
     end
 
     def method_missing(method_name, *args, &block)

--- a/lib/ruby_home/characteristic.rb
+++ b/lib/ruby_home/characteristic.rb
@@ -72,6 +72,28 @@ module RubyHome
       constraints.fetch("ValidValues", {}).keys.map(&:to_i)
     end
 
+    def minimum_value
+      return unless numeric_constraints?
+
+      constraints["MinimumValue"]
+    end
+
+    def maximum_value
+      return unless numeric_constraints?
+
+      constraints["MaximumValue"]
+    end
+
+    def step_value
+      return unless numeric_constraints?
+
+      constraints["StepValue"]
+    end
+
+    def numeric_constraints?
+      format == "uint32" || format == "float"
+    end
+
     def method_missing(method_name, *args, &block)
       value.send(method_name, *args, &block)
     end

--- a/lib/ruby_home/http/serializers/characteristic_serializer.rb
+++ b/lib/ruby_home/http/serializers/characteristic_serializer.rb
@@ -17,6 +17,7 @@ module RubyHome
         }
           .merge(value_hash(characteristic))
           .merge(valid_values_hash(characteristic))
+          .merge(numeric_constraints(characteristic))
       end
 
       private
@@ -41,6 +42,16 @@ module RubyHome
         else
           {"valid-values" => characteristic.valid_values}
         end
+      end
+
+      def numeric_constraints(characteristic)
+        return {} unless characteristic.numeric_constraints?
+
+        {
+          "minValue" => characteristic.minimum_value,
+          "maxValue" => characteristic.maximum_value,
+          "minStep" => characteristic.step_value,
+        }.compact
       end
     end
   end

--- a/lib/ruby_home/http/serializers/characteristic_serializer.rb
+++ b/lib/ruby_home/http/serializers/characteristic_serializer.rb
@@ -45,7 +45,7 @@ module RubyHome
       end
 
       def numeric_constraints(characteristic)
-        return {} unless characteristic.format_numeric?
+        return {} unless characteristic.numeric_format?
 
         {
           "minValue" => characteristic.minimum_value,

--- a/lib/ruby_home/http/serializers/characteristic_serializer.rb
+++ b/lib/ruby_home/http/serializers/characteristic_serializer.rb
@@ -50,7 +50,7 @@ module RubyHome
         {
           "minValue" => characteristic.minimum_value,
           "maxValue" => characteristic.maximum_value,
-          "minStep" => characteristic.step_value,
+          "minStep" => characteristic.step_value
         }.compact
       end
     end

--- a/lib/ruby_home/http/serializers/characteristic_serializer.rb
+++ b/lib/ruby_home/http/serializers/characteristic_serializer.rb
@@ -45,7 +45,7 @@ module RubyHome
       end
 
       def numeric_constraints(characteristic)
-        return {} unless characteristic.numeric_constraints?
+        return {} unless characteristic.format_numeric?
 
         {
           "minValue" => characteristic.minimum_value,

--- a/spec/http/requests/accessories_spec.rb
+++ b/spec/http/requests/accessories_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "GET /accessories" do
       characteristic = characteristics.find { |c| c["iid"] == cooling_threshold_temperature.instance_id }
       expect(characteristic).to include(
         "minValue" => 10,
-        "maxValue" => 30,
+        "maxValue" => 35,
         "minStep" => 0.1
       )
     end

--- a/spec/http/requests/accessories_spec.rb
+++ b/spec/http/requests/accessories_spec.rb
@@ -62,6 +62,21 @@ RSpec.describe "GET /accessories" do
       valid_values = JSON.parse(last_response.body)["accessories"][0]["services"][0]["characteristics"][0]["valid-values"]
       expect(valid_values).to eql([0, 1])
     end
+
+    it "includes accessories services characteristics numeric properties" do
+      heater_cooler = RubyHome::ServiceFactory.create(:heater_cooler, cooling_threshold_temperature: 10)
+      cooling_threshold_temperature = heater_cooler.cooling_threshold_temperature
+
+      get "/accessories", nil, {"CONTENT_TYPE" => "application/hap+json"}
+
+      characteristics = JSON.parse(last_response.body).dig("accessories", 0, "services", 0, "characteristics")
+      characteristic = characteristics.find { |c| c["iid"] == cooling_threshold_temperature.instance_id }
+      expect(characteristic).to include(
+        "minValue" => 10,
+        "maxValue" => 30,
+        "minStep" => 0.1
+      )
+    end
   end
 
   def create_fan_accessory

--- a/spec/http/requests/accessories_spec.rb
+++ b/spec/http/requests/accessories_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "GET /accessories" do
       expect(valid_values).to eql([0, 1])
     end
 
-    it "includes accessories services characteristics numeric properties" do
+    it "includes float format characteristics numeric properties" do
       heater_cooler = RubyHome::ServiceFactory.create(:heater_cooler, cooling_threshold_temperature: 10)
       cooling_threshold_temperature = heater_cooler.cooling_threshold_temperature
 
@@ -75,6 +75,21 @@ RSpec.describe "GET /accessories" do
         "minValue" => 10,
         "maxValue" => 30,
         "minStep" => 0.1
+      )
+    end
+
+    it "includes int format characteristics numeric properties" do
+      window_covering = RubyHome::ServiceFactory.create(:window_covering, target_horizontal_tilt_angle: 0)
+      target_horizontal_tilt_angle = window_covering.target_horizontal_tilt_angle
+
+      get "/accessories", nil, {"CONTENT_TYPE" => "application/hap+json"}
+
+      characteristics = JSON.parse(last_response.body).dig("accessories", 0, "services", 0, "characteristics")
+      characteristic = characteristics.find { |c| c["iid"] == target_horizontal_tilt_angle.instance_id }
+      expect(characteristic).to include(
+        "minValue" => -90,
+        "maxValue" => 90,
+        "minStep" => 1
       )
     end
   end


### PR DESCRIPTION
This exposes the optional Properties of Characteristic Objects in JSON 

- Minimum Value
- Maximum Value
- Step Value

These characteristics are only relevant for characteristics of format int or float. They allow finer specification of characteristics beyond the defaults. For example: if someone wants to limit the cooling temperature of an AC unit `heater_cooler` with no heater between 17C and 31C in 1C steps.
